### PR TITLE
Update design system documentation

### DIFF
--- a/docs/design-system/about-the-design-system.md
+++ b/docs/design-system/about-the-design-system.md
@@ -21,7 +21,7 @@ sort_order: 1
 # About the design system
 The B.C. Design System provides components and resources to help developers and designers build accessible user interfaces faster and more consistently.
 
-As of February 2024, design system is currently in active development. It will replace the [legacy design system](#the-legacy-design-system), previously hosted on DevHub. The legacy design system is no longer supported, and will eventually be deprecated and archived.
+As of February 2024, the design system is currently in active development. It will replace the [legacy design system](#the-legacy-design-system), previously hosted on DevHub. The legacy design system is no longer supported, and will eventually be deprecated and archived.
 
 ## On this page
 - [How the design system works](#how-the-design-system-works)

--- a/docs/design-system/about-the-design-system.md
+++ b/docs/design-system/about-the-design-system.md
@@ -23,13 +23,6 @@ The B.C. Design System provides components and resources to help developers and 
 
 As of February 2024, the design system is currently in active development. It will replace the [legacy design system](#the-legacy-design-system), previously hosted on DevHub. The legacy design system is no longer supported, and will eventually be deprecated and archived.
 
-## On this page
-- [How the design system works](#how-the-design-system-works)
-- [Releases](#releases)
-- [Design system management](#design-system-management)
-- [Contribute to the design system](#contribute-to-the-design-system)
-- [The legacy design system](#the-legacy-design-system)
-
 ## How the design system works
 The B.C. Design System will comprise 4 core elements:
 

--- a/docs/design-system/about-the-design-system.md
+++ b/docs/design-system/about-the-design-system.md
@@ -3,7 +3,7 @@ title: About the design system
 
 slug: about-the-design-system
 
-description: Describes the design system for B.C. Government projects.
+description: Describes the design system for B.C. government projects.
 
 keywords: design, UI, components, interface components, open source, tools, resources
 
@@ -13,7 +13,7 @@ audience: developer
 
 author: Marcus Kernohan
 
-content_owner: Tyler Krys
+content_owner: Marcus Kernohan
 
 sort_order: 1
 ---
@@ -21,7 +21,7 @@ sort_order: 1
 # About the design system
 The B.C. Design System provides components and resources to help developers and designers build accessible user interfaces faster and more consistently.
 
-The design system is currently in active development. It will replace the legacy design system, hosted on DevHub. The legacy design system is no longer supported, and will eventually be deprecated and archived.
+As of February 2024, design system is currently in active development. It will replace the legacy design system, hosted on DevHub. The legacy design system is no longer supported, and will eventually be deprecated and archived.
 
 ## On this page
 - [How the design system works](#how-the-design-system-works)

--- a/docs/design-system/about-the-design-system.md
+++ b/docs/design-system/about-the-design-system.md
@@ -33,7 +33,7 @@ As of February 2024, design system is currently in active development. It will r
 ## How the design system works
 The B.C. Design System will comprise 4 core elements:
 
-* [Design tokens](https://www.npmjs.com/package/@bcgov/design-tokens?activeTab=versions) (currently in beta, version 2.0.1)
+* [Design tokens](https://www.npmjs.com/package/@bcgov/design-tokens?activeTab=versions) (currently in beta)
 * React component library (in development)
 * Design library in Figma (in development)
 * Documentation hub (in development)

--- a/docs/design-system/about-the-design-system.md
+++ b/docs/design-system/about-the-design-system.md
@@ -11,7 +11,7 @@ page_purpose: Discusses the design system, who manages it and how teams and deve
 
 audience: developer
 
-author: Jonathan Bond
+author: Marcus Kernohan
 
 content_owner: Tyler Krys
 
@@ -19,50 +19,62 @@ sort_order: 1
 ---
 
 # About the design system
+The B.C. Design System provides components and resources to help developers and designers build accessible user interfaces faster and more consistently.
 
-The [BC Government Design System for Digital Services](https://developer.gov.bc.ca/Design-System/About-the-Design-System) helps developers and designers build better digital products and services. It’s a collection of digital resources and tools, including a library of reusable user interface components and design patterns. The system makes it easier and faster to build custom B.C. government websites and applications.
+The design system is currently in active development. It will replace the legacy design system, hosted on DevHub. The legacy design system is no longer supported, and will eventually be deprecated and archived.
 
 ## On this page
-
-- [Design system management](#design-system-management)
 - [How the design system works](#how-the-design-system-works)
+- [Releases](#releases)
+- [Design system management](#design-system-management)
 - [Contribute to the design system](#contribute-to-the-design-system)
-
-Components are collectively built by the government community, meet accessibility standards and are open for input and improvement.
-
-Use the design system to customize B.C. government sites and applications. For more information about applying for external URLs, contact the B.C. government [Joint Working Group](https://www2.gov.bc.ca/gov/content/governments/services-for-government/service-experience-digital-delivery/digital-delivery/web-property-process/web-property-applications).
-
-## Design system management
-
-A team of designers, developers and the government community manage the design system. The system is part of DevHub, a project that brings together user interface and backend resources for digital teams.
-
-The design system is open source, which means that anybody can provide input, offer suggestions and get involved. The system is collectively built and maintained by the government community.
+- [The legacy design system](#the-legacy-design-system)
 
 ## How the design system works
+The B.C. Design System will comprise 4 core elements:
 
-The design system gives developers the tools they need to build digital government products and services. Because the community produces all tools and resources, we're committed to:
+* [Design tokens](https://www.npmjs.com/package/@bcgov/design-tokens?activeTab=versions) (currently in beta, version 2.0.1)
+* React component library (in development)
+* Design library in Figma (in development)
+* Documentation hub (in development)
 
-- **Maintenance:** The community and design system management team supports the maintenance and development of new resources and tools. This means you can flag issues and they’ll be addressed, discuss rationale and directly chat with the management team whenever you need.
+The goal of the design system is to provide a common set of resources for both developers and designers, to help enable more efficient collaboration. 
 
-- **Collaboration:** The system is only valuable if the community finds it valuable. If a tool or resource isn’t meeting your needs, tell us why and work with us to make it better. We can also come to you, in your office, at your desk and share what’s new, ask what you need and share how you can get involved.
+## Releases
 
-- **Open-source development:** The system is built in GitHub and meant to be shared and improved by everyone. The code is open source and our work is in the open. We are transparent about how choices are made and tools are improved.
+### Design tokens
+The B.C. Design Tokens package provides a straightforward way for developers and designers to access and implement the basic visual language of the B.C. government's digital look and feel. Tokens provide flexible, standardised options for basic design decisions like:
+
+* Colour
+* Typography
+* Spacing
+* Sizing
+
+For developers, tokens are exposed as CSS and JavaScript variables. Support for other languages may be provided in the future. For designers, tokens are published as styles and variables in Figma.
+
+To start using tokens:
+
+* [Install the B.C. Design Tokens package via npm](https://www.npmjs.com/package/@bcgov/design-tokens?activeTab=readme)
+* [Get the B.C. Design Tokens library via Figma Community](https://www.figma.com/community/file/1326994583954765832)
+
+### Component library
+The component library will provide an inventory of reusable user interface components, including:
+
+* Components in Figma
+* Reference implementations in React
+
+Support for other languages and frameworks is currently out-of-scope.
+
+The component library is currently in active development. 
+
+A [proof-of-concept/preview of the React library](https://www.npmjs.com/package/@bcgov/design-system-react-components) is published on npm.
+
+## Design system management
+The B.C. Design System is maintained by Government Digital Experience (GDX), a division of the Ministry of Citizens' Services. You can contact the design system team at [designsystem@gov.bc.ca](mailto:designsystem@gov.bc.ca) or on [GitHub](https://github.com/bcgov/design-system).
 
 ## Contribute to the design system
+The design system is an open-source project. Its source code is licensed under the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0).
 
-You can contribute to the design system by doing any of the following:
+## The legacy design system
+The previous B.C. government design system is not actively supported. Legacy documentation and components are available on [DevHub](https://developer.gov.bc.ca/components) and [GitHub](https://github.com/bcgov/design-system) for reference. These resources will be officially deprecated and archived after the new BCDS component library is released.
 
-- Help with design by [suggesting a component](https://developer.gov.bc.ca/Design-System/Propose-a-New-Component) or improving documentation.
-
-- Help with code by contributing to the code guide or reporting an issue.
-
-- Help with usability by contributing to component discussions or providing research findings.
-
----
-Related links:
-
-* [BC Design System](https://developer.gov.bc.ca/Design-System/About-the-Design-System)
-* [Joint Working Group](https://www2.gov.bc.ca/gov/content/governments/services-for-government/service-experience-digital-delivery/digital-delivery/web-property-process/web-property-applications)
-* [Propose a New Component](https://developer.gov.bc.ca/Design-System/Propose-a-New-Component)
-
----

--- a/docs/design-system/about-the-design-system.md
+++ b/docs/design-system/about-the-design-system.md
@@ -21,7 +21,7 @@ sort_order: 1
 # About the design system
 The B.C. Design System provides components and resources to help developers and designers build accessible user interfaces faster and more consistently.
 
-As of February 2024, design system is currently in active development. It will replace the legacy design system, hosted on DevHub. The legacy design system is no longer supported, and will eventually be deprecated and archived.
+As of February 2024, design system is currently in active development. It will replace the [legacy design system](#the-legacy-design-system), previously hosted on DevHub. The legacy design system is no longer supported, and will eventually be deprecated and archived.
 
 ## On this page
 - [How the design system works](#how-the-design-system-works)
@@ -76,5 +76,5 @@ The B.C. Design System is maintained by Government Digital Experience (GDX), a d
 The design system is an open-source project. Its source code is licensed under the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0).
 
 ## The legacy design system
-The previous B.C. government design system is not actively supported. Legacy documentation and components are available on [DevHub](https://developer.gov.bc.ca/components) and [GitHub](https://github.com/bcgov/design-system) for reference. These resources will be officially deprecated and archived after the new BCDS component library is released.
+The previous B.C. government design system is not actively supported. Legacy documentation and components are available on [Classic DevHub](https://classic.developer.gov.bc.ca/About-the-Design-System) for reference. These resources will be officially deprecated and archived after the new BCDS component library is released.
 


### PR DESCRIPTION
This change rewrites 'about the design system' page in the BCDG, to bring it up to date and explain our current plans for the B.C. Design System.