### PR TITLE
Fixed links

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -4,17 +4,17 @@ This document is a living guide to application development for the B.C governmen
 
 ## Current Topics
 
-### [GitHub in the B.C. government](./use-github-in-bcgov/bc-government-organizations-in-github/)
+### [GitHub in the B.C. government](use-github-in-bcgov/bc-government-organizations-in-github.md)
 
 GitHub is the preferred tool for B.C. government development team to store and share code. Learn about available options related to GitHub and how to license and manage code repositories.
 
-### [Rocket.Chat](./rocketchat/steps-to-join-rocketchat/)
+### [Rocket.Chat](rocketchat/steps-to-join-rocketchat.md)
 
 We use Rocket.Chat for technical discussions. It’s similar to Slack or Discord. 
 
 Learn how to join and use Rocket.Chat and connect with other developers across the B.C. government. 
 
-### [Design System](./design-system/about-the-design-system/)
+### [Design System](design-system/about-the-design-system.md)
 
 Learn what the BC Government Design System for Digital Services can do for your project.
 

--- a/docs/rocketchat/get-help-in-rocketchat.md
+++ b/docs/rocketchat/get-help-in-rocketchat.md
@@ -82,14 +82,14 @@ If you’ve been following instructions on a StackOverflow thread, provide a lin
 What are you asking the community for? Do you want a solution to the problem? A link to documentation you can use? An alternative way to complete a task? Let the community know what kind of support you’re looking for.
 
 ## Posting a question
-Send your message in the appropriate Rocket.Chat channel and check back often to see if you’ve gotten a reply. Read the [Rocket.Chat etiquette page](https://docs.developer.gov.bc.ca/rocketchat-etiquette/) for more information on how to use Rocket.Chat, and what to do if you don’t get a satisfactory answer.
+Send your message in the appropriate Rocket.Chat channel and check back often to see if you’ve gotten a reply. Read the [Rocket.Chat etiquette page](rocketchat-etiquette.md) for more information on how to use Rocket.Chat, and what to do if you don’t get a satisfactory answer.
 
 
 ---
 ---
 ## Related pages
 
-- [Steps to join Rocket.Chat](https://docs.developer.gov.bc.ca/steps-to-join-rocketchat/)
-- [Rocket.Chat etiquette](https://docs.developer.gov.bc.ca/rocketchat-etiquette/)
-- [Rocket.Chat channel descriptions](https://docs.developer.gov.bc.ca/rocketchat-channel-descriptions/)
+- [Steps to join Rocket.Chat](steps-to-join-rocketchat.md)
+- [Rocket.Chat etiquette](rocketchat-etiquette.md)
+- [Rocket.Chat channel descriptions](rocketchat-channel-descriptions.md)
 - [Official Rocket.Chat documentation](https://docs.rocket.chat/)

--- a/docs/rocketchat/rocketchat-channel-descriptions.md
+++ b/docs/rocketchat/rocketchat-channel-descriptions.md
@@ -125,7 +125,7 @@ When naming a team channel, make sure you include your team’s name and the top
 ---
 ## Related pages
 
-- [Steps to join Rocket.Chat](https://docs.developer.gov.bc.ca/steps-to-join-rocketchat/)
-- [Rocket.Chat etiquette](https://docs.developer.gov.bc.ca/rocketchat-etiquette/)
-- [Get help in Rocket.Chat](https://docs.developer.gov.bc.ca/get-help-in-rocketchat/)
+- [Steps to join Rocket.Chat](steps-to-join-rocketchat.md)
+- [Rocket.Chat etiquette](rocketchat-etiquette.md)
+- [Get help in Rocket.Chat](get-help-in-rocketchat.md)
 - [Official Rocket.Chat documentation](https://docs.rocket.chat/)

--- a/docs/rocketchat/rocketchat-etiquette.md
+++ b/docs/rocketchat/rocketchat-etiquette.md
@@ -38,7 +38,7 @@ We follow a community-based support model, and all members of the platform commu
 
 If you need help or have a question about working on the platform, you can post a question in Rocket.Chat. Then, it can be answered by another member on the platform.
 
-If you aren’t sure what channel you should use to ask a question or share information, you can review the [channel descriptions](https://docs.developer.gov.bc.ca/rocketchat-channel-descriptions/) to find out what each channel is for. Choose the best channel for your message. If none of the channels seem suitable, you can use the #general channel to post your message.
+If you aren’t sure what channel you should use to ask a question or share information, you can review the [channel descriptions](rocketchat-channel-descriptions.md) to find out what each channel is for. Choose the best channel for your message. If none of the channels seem suitable, you can use the #general channel to post your message.
 
 Typical response times in Rocket.Chat are:
 
@@ -62,7 +62,7 @@ Check Rocket.Chat often to keep up with discussions and see new posts. We do our
 ---
 ## Related pages
 
-- [Steps to join Rocket.Chat](https://docs.developer.gov.bc.ca/steps-to-join-rocketchat/)
-- [Rocket.Chat channel descriptions](https://docs.developer.gov.bc.ca/rocketchat-channel-descriptions/)
-- [Get help in Rocket.Chat](https://docs.developer.gov.bc.ca/get-help-in-rocketchat/)
+- [Steps to join Rocket.Chat](steps-to-join-rocketchat.md)
+- [Rocket.Chat channel descriptions](rocketchat-channel-descriptions.md)
+- [Get help in Rocket.Chat](get-help-in-rocketchat.md)
 - [Official Rocket.Chat documentation](https://docs.rocket.chat/)

--- a/docs/rocketchat/steps-to-join-rocketchat.md
+++ b/docs/rocketchat/steps-to-join-rocketchat.md
@@ -110,7 +110,7 @@ Include answers to the following questions in your email:
 ---
 ## Related pages
 
-- [Rocket.Chat etiquette](https://docs.developer.gov.bc.ca/rocketchat-etiquette/)
-- [Rocket.Chat channel descriptions](https://docs.developer.gov.bc.ca/rocketchat-channel-descriptions/)
-- [Get help in Rocket.Chat](https://docs.developer.gov.bc.ca/get-help-in-rocketchat/)
+- [Rocket.Chat etiquette](rocketchat-etiquette.md)
+- [Rocket.Chat channel descriptions](rocketchat-channel-descriptions.md)
+- [Get help in Rocket.Chat](get-help-in-rocketchat.md)
 - [Official Rocket.Chat documentation](https://docs.rocket.chat/)

--- a/docs/use-github-in-bcgov/bc-government-organizations-in-github.md
+++ b/docs/use-github-in-bcgov/bc-government-organizations-in-github.md
@@ -53,10 +53,10 @@ Your product team can only have a **permanent**, private repository in `bcgov-c`
 
 We have an Enterprise-Managed User (EMU) tier of GitHub Enterprise procured within the BC Government. The Enterprise account acts as administrative umbrella above multiple Ministry IMB-managed GitHub Orgs. It is designed for Ministry-specific **private** organizations linked to the B.C. government's Enterprise account. These organizations permanently store teams' private repositories with closed-sourced code that is intended to remain closed forever. 
 
-User licenses are required for the members of these organizations. For more information on creating a private organization linked to the GitHub enterprise account, see [GitHub Enterprise user licences in the B.C. government](../github-enterprise-user-licenses-bc-government/).
+User licenses are required for the members of these organizations. For more information on creating a private organization linked to the GitHub enterprise account, see [GitHub Enterprise user licences in the B.C. government](github-enterprise-user-licenses-bc-government.md).
 
 * Product teams that need a permanent location for their closed-source code should use this repository.
-* Each ministry team must purchase their own [user licenses](../github-enterprise-user-licenses-bc-government/) to use the organization.
+* Each ministry team must purchase their own [user licenses](github-enterprise-user-licenses-bc-government.md#acquiring-github-enterprise-user-licences) to use the organization.
 * Only ministry GitHub administrators can create repositories in this organization. Consult with your ministry's Information Management Branch (IMB) to get in touch with the GitHub administrators.
 
 ### Security Insights for GitHub Enterprise-linked organizations
@@ -70,8 +70,8 @@ Related links:
 * [bcgov](https://github.com/bcgov)
 * [Digital Principles for BC Government](https://digital.gov.bc.ca/resources/digital-principles)
 * [Just Ask! tool](https://just-ask.developer.gov.bc.ca/)
-* [GitHub Enterprise user licences in the BC government](../github-enterprise-user-licenses-bc-government/)
-* [Remove a user's BCGov GitHub access](../remove-user-bcgov-github-access/)
-* [Common platform requests in the BC Gov Private Cloud PaaS](%WORDPRESS_BASE_URL%/private-cloud/support-and-community/devops-requests-in-the-bc-gov-private-cloud-paas/)
+* [GitHub Enterprise user licences in the BC government](github-enterprise-user-licenses-bc-government.md)
+* [Remove a user's BCGov GitHub access](remove-user-bcgov-github-access.md)
+* [Common platform requests in the BC Gov Private Cloud PaaS](https://cloud.gov.bc.ca/private-cloud/support-and-community/devops-requests-in-the-bc-gov-private-cloud-paas/)
 
 ---

--- a/docs/use-github-in-bcgov/evaluate-open-source-content.md
+++ b/docs/use-github-in-bcgov/evaluate-open-source-content.md
@@ -22,7 +22,7 @@ sort_order: 5
 
 Use the following guidelines to make sure that you are able to use existing, open-source content on GitHub.
 
-For more information on approval requirements, see [Start working in the BC Gov GitHub organization](../start-working-in-bcgov-github-organization/).
+For more information on approval requirements, see [Start working in the BC Gov GitHub organization](start-working-in-bcgov-github-organization.md).
 
 ## On this page
 - [Privacy](#privacy)
@@ -51,7 +51,7 @@ Make sure to meet the following requirements:
 - Content is created solely by B.C. government employees
 - Content is fully owned by the B.C. government and doesn't contain any third-party content. Collect copies of any contracts related to the content for review with the [Intellectual Property Program (IPP)](https://www2.gov.bc.ca/gov/content/governments/services-for-government/policies-procedures/intellectual-property/intellectual-property-program)
 - Content has no terms of use or exclusive licences that prohibit the Province from licensing the content on GitHub. Collect information concerning any terms of use or licences related to the content for review with the IPP
-- You have [authority to license the content](../license-your-github-repository/)
+- You have [authority to license the content](license-your-github-repository.md)
 
 Ministries  **must**  contact the IPP to assist in this assessment. Any legal review or legal advice is provided by the Legal Services Branch.
 
@@ -70,9 +70,9 @@ Make sure that the material has been labelled **Public**, using the [Information
 ---
 Related links:
 
-- [Start working in the BCGov GitHub organization](../start-working-in-bcgov-github-organization/)
+- [Start working in the BCGov GitHub organization](start-working-in-bcgov-github-organization.md)
 - [Intellectual Property Program (IPP)](https://www2.gov.bc.ca/gov/content/governments/services-for-government/policies-procedures/intellectual-property/intellectual-property-program)
-- [License your GitHub repository](../license-your-github-repository/)
+- [License your GitHub repository](license-your-github-repository.md)
 - [Ministry Information Security Officer (MISO)](https://www2.gov.bc.ca/gov/content/governments/services-for-government/policies-procedures/information-security-policy-and-guidelines/role-of-miso)
 - [Information Security Classification Framework](https://www2.gov.bc.ca/gov/content/governments/services-for-government/information-management-technology/information-security/information-security-classification)
 

--- a/docs/use-github-in-bcgov/github-enterprise-user-licenses-bc-government.md
+++ b/docs/use-github-in-bcgov/github-enterprise-user-licenses-bc-government.md
@@ -4,7 +4,7 @@
 
 All code built for B.C. government for staff or contracted developers should be open source by default and stored in the public [`bcgov` organization on GitHub.com](https://github.com/bcgoc). If you have closed source code and still want to use GitHub's functionality, you can store your code in a private repository within the B.C. government's [GitHub Enterprise environment](https://github.com/enterprises/bcgov-ent/). This page contains details related to that environment and its use.
 
-For more information about B.C. government GitHub organizations outside of GitHub Enterprise, see [B.C. government organizations in GitHub](../bc-government-organizations-in-github/).
+For more information about B.C. government GitHub organizations outside of GitHub Enterprise, see [B.C. government organizations in GitHub](bc-government-organizations-in-github.md).
 
 ## B.C. government GitHub Enterprise Overview
 
@@ -35,7 +35,7 @@ This section outlines what is involved in acquiring the licenses required to use
 ### Pre-requisites:
 
 - Confirm that your intended use of GitHub Enterprise aligns with its purpose, which is exclusively for storing code that can't be, or isn't currently, open source.
-- Confirm whether your ministry or sector is using GitHub Enterprise and know who in your IMB/ISB is responsible for managing access. If you aren't sure who to contact within your IMB/ISB, please contact the [Developer Experience Team](developer.experience@gov.bc.ca) for assistance.
+- Confirm whether your ministry or sector is using GitHub Enterprise and know who in your IMB/ISB is responsible for managing access. If you aren't sure who to contact within your IMB/ISB, please contact the [Developer Experience Team](mailto:developer.experience@gov.bc.ca) for assistance.
 - Identify who is responsible within your business area for submitting iStore orders.
 
 ### Steps
@@ -58,6 +58,6 @@ Our team has created the artifact below which captures the steps and teams invol
 ---
 Related links:
 
-* [BC Government Organizations in GitHub](../bc-government-organizations-in-github/)
+* [BC Government Organizations in GitHub](bc-government-organizations-in-github.md)
 
 ---

--- a/docs/use-github-in-bcgov/remove-user-bcgov-github-access.md
+++ b/docs/use-github-in-bcgov/remove-user-bcgov-github-access.md
@@ -42,7 +42,7 @@ Related links:
 
 * [DevOps-Requests Repo](https://github.com/BCDevOps/devops-requests)
 * [Just Ask! tool](https://just-ask.developer.gov.bc.ca/)
-* [BC Government organizations in GitHub](../bc-government-organizations-in-github/)
-* [Common platform requests in the BC Gov Private Cloud PaaS](%WORDPRESS_BASE_URL%/private-cloud/support-and-community/devops-requests-in-the-bc-gov-private-cloud-paas/)
+* [BC Government organizations in GitHub](bc-government-organizations-in-github.md)
+* [Common platform requests in the BC Gov Private Cloud PaaS](https://cloud.gov.bc.ca/private-cloud/support-and-community/devops-requests-in-the-bc-gov-private-cloud-paas/)
 
 ---

--- a/docs/use-github-in-bcgov/required-pages-for-github-repository.md
+++ b/docs/use-github-in-bcgov/required-pages-for-github-repository.md
@@ -35,7 +35,7 @@ When you create a repository in the `bcgov` organization, add the following mark
 - [Contribution guidelines](#contribution-guidelines)
 
 ## Licence
-Choose a licence and place a licence file in your repository before you do anything else. For important information on licences, see [License your GitHub repository](../license-your-github-repository/).
+Choose a licence and place a licence file in your repository before you do anything else. For important information on licences, see [License your GitHub repository](license-your-github-repository.md).
 
 Depending on the licence you choose, add boilerplate text for the applicable licence to your README file.
 
@@ -48,7 +48,7 @@ Make sure to include the following:
 
 - A brief description of your project
 - An overview on how to contribute to the repository with a link to your contribution guidelines
-- Depending on your licence, boilerplate text for the applicable licence. For more information, see [License your GitHub repository](../license-your-github-repository/)
+- Depending on your licence, boilerplate text for the applicable licence. For more information, see [License your GitHub repository](license-your-github-repository.md)
 - A link to your code of conduct file
 
 See a [sample README file](https://github.com/bcgov/BC-Policy-Framework-For-GitHub/blob/master/BC-Gov-Org-HowTo/SAMPLE-README.md).
@@ -73,7 +73,7 @@ See a [sample contributing file](https://github.com/bcgov/BC-Policy-Framework-Fo
 Related links:
 
 * [About READMEs](https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-readmes)
-* [License your GitHub repository](../license-your-github-repository/)
+* [License your GitHub repository](license-your-github-repository.md)
 * [Contributor Covenant](https://www.contributor-covenant.org/version/1/4/code-of-conduct/)
 * [Healthy contributions](https://docs.github.com/en/communities/setting-up-your-project-for-healthy-contributions)
 * [Using pull requests](https://help.github.com/articles/using-pull-requests/)

--- a/docs/use-github-in-bcgov/start-working-in-bcgov-github-organization.md
+++ b/docs/use-github-in-bcgov/start-working-in-bcgov-github-organization.md
@@ -20,7 +20,7 @@ sort_order: 8
 
 # Start working in the BCGov GitHub organization
 
-If you plan to share code developed by or for the B.C. government, [evaluate the content](../evaluate-open-source-content/) and get approval from your deputy minister. Deputy ministers may choose to delegate this authority to ministry chief information officers (CIOs).
+If you plan to share code developed by or for the B.C. government, [evaluate the content](evaluate-open-source-content.md) and get approval from your deputy minister. Deputy ministers may choose to delegate this authority to ministry chief information officers (CIOs).
 
 ## On this page
 
@@ -30,7 +30,7 @@ If you plan to share code developed by or for the B.C. government, [evaluate the
 
 The B.C. government follows the Open Development Standard, which outlines the following:
 
-* [Minimum content requirements](../required-pages-for-github-repository/): README, contributing file, code of conduct and license
+* [Minimum content requirements](required-pages-for-github-repository.md): README, contributing file, code of conduct and license
 * Roles and responsibilities
 * Basic mechanics of working in GitHub
 
@@ -46,7 +46,7 @@ Projects like this follow two basic approaches, but can vary.
 
 In both cases, the basic steps to release the code are similar, while the implications for project management and resourcing are not. Key requirements in these scenarios include the following:
 
-- Confirm your [authority to license](../license-your-github-repository/)
+- Confirm your [authority to license](license-your-github-repository.md)
 
 	Choose an open-source license and consult with the Intellectual Property Program (IPP) to make sure government has the right to release the code.
 
@@ -66,9 +66,9 @@ If you are intending to maintain an active project, make sure to establish the a
 
 These are projects that you want to manage as an open-source, collaborative project.
 
-- Choose an open-source licence and confirm your [authority to license](../license-your-github-repository/)
+- Choose an open-source licence and confirm your [authority to license](license-your-github-repository.md)
 - Determine how contributions are made and managed and include this information in the contributor file in the repository.
-- [Create the minimum required content](../required-pages-for-github-repository/).
+- [Create the minimum required content](required-pages-for-github-repository.md).
 - Add a [Contributor Code of Conduct](http://contributor-covenant.org/) to your repository. This document lets people know that all are welcome to contribute, and that all who contribute pledge to make participation in the project a harassment-free experience for everyone. Include a code of conduct and provide a contact method (in the placeholder) so that people know how to report violations. Introduce the code of conduct in your `readme.md`.
 
 ## Contribute to outside code or projects
@@ -82,15 +82,15 @@ There may be circumstances where it's useful and appropriate for employees to co
 
 	If the project uses a reciprocal or "copyleft" license, such as GPL or Mozilla, make sure you understand the requirements for publishing any modifications you make to the code.
 
-- Confirm your [authority to license](../license-your-github-repository/)
+- Confirm your [authority to license](license-your-github-repository.md)
 
 Employees can also contribute to non-B.C. government owned intellectual property rights outside their professional roles by using their personal email linked to their GitHub account.
 
 ---
 Related links:
 
-* [Evaluate the content](../evaluate-open-source-content/)
-* [Required pages for a GitHub repository](../required-pages-for-github-repository/)
-* [License your GitHub repository](../license-your-github-repository/)
+* [Evaluate the content](evaluate-open-source-content.md)
+* [Required pages for a GitHub repository](required-pages-for-github-repository.md)
+* [License your GitHub repository](license-your-github-repository.md)
 
 ---

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -5,7 +5,6 @@ docs_dir: "docs"
 edit_uri: edit/main/docs/
 plugins:
     - techdocs-core
-    - ezlinks
 markdown_extensions:
     - md_in_html
 


### PR DESCRIPTION
Links were not working on the mvp site. 

The following changes were made:

- Removed the ezlink plugin as it was mangling mailto elements. It was trying to render them as links.
- Updated links that were pointing to the docs.developer.gov.bc.ca site
- Updated links that had %WORDPRESS% variable in them. 


