### PR TITLE
update owner so backstage doesn't look in the default namespace for t…

### DIFF
--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -10,4 +10,4 @@ metadata:
 spec:
   type: documentation
   lifecycle: experimental
-  owner: "developer-experience"
+  owner: "bcgov/developer-experience"


### PR DESCRIPTION
…he team. this popped up when we started using multiple organizations.