### PR TITLE
Updated links

### DIFF
--- a/docs/content-partner-guide.md
+++ b/docs/content-partner-guide.md
@@ -28,7 +28,7 @@ The steps captured in the diagram are as follows:
 
 - As a documentation writer, you edit or create files that will eventually be published in DevHub in your team's GitHub repository . 
 - When you want to preview your documentation, you can save your files to a preview branch (any branch other than a repo's default/main branch) in GitHub and after a few moments, it will then be available for review on the [preview instance of DevHub](https://dev.developer.gov.bc.ca). 
-- Once you're happy with your edits, you'll save your files into your repository's main branch. In this case, after a few moments, your latest documentation will be published and available on the [production DevHub instance](https://mvp.developer.gov.bc.ca). 
+- Once you're happy with your edits, you'll save your files into your repository's main branch. In this case, after a few moments, your latest documentation will be published and available on the [production DevHub instance](https://developer.gov.bc.ca). 
 - Each time you have changes or additions to make to your documentation, you iterate through this same process.
 
 For those interested in the automated aspect of the process above, it is provided by a purpose-built GitHub "Action" that we have create to simplify things for our content partners, and maintain consistency in the publishing process. It takes care of converting your Markdown content into an HTML format that is compatible with DevHub, packaging it up, and transferring it to a location that DevHub can access it. Your team will be provided with access to the Action as part of the setup steps described [below](#how-do-we-get-set-up-to-have-our-documentation-published-in-devhub).  

--- a/docs/use-github-in-bcgov/bc-government-organizations-in-github.md
+++ b/docs/use-github-in-bcgov/bc-government-organizations-in-github.md
@@ -63,7 +63,7 @@ By **July 30, 2024**, users must follow prompts in GitHub to link their personal
 
 If the instructions to re-add users doesn't work, please submit a ticket at [Jira Service Manager](https://citz-do.atlassian.net/servicedesk/customer/portal/2)
  
-[Learn more about how linking works](github-transition-guide.md#technical-information).  
+[Learn more about how linking works](github-transition-guide.md#technical-transition-guide).  
 
 ### Costs
  

--- a/docs/use-github-in-bcgov/github-transition-guide.md
+++ b/docs/use-github-in-bcgov/github-transition-guide.md
@@ -1,6 +1,6 @@
 # Transition Guides
 
-The IDIR transition guide offers more detailed information about IDIRs and how they relate to the GitHub SSO upgrade. Our [technical transition guide](https://dev.developer.gov.bc.ca/docs/default/component/bc-developer-guide/use-github-in-bcgov/github-transition-guide/#technical-information) helps preparation with with validating GitHub ID and IDIR linking.
+The IDIR transition guide offers more detailed information about IDIRs and how they relate to the GitHub SSO upgrade. Our [technical transition guide](#technical-transition-guide) helps preparation with with validating GitHub ID and IDIR linking.
 
 We published an overview about [the SSO upgrade](bc-government-organizations-in-github.md#single-sign-on-is-coming-to-the-bc-governments-github-organizations) on DevHub. 
 
@@ -62,7 +62,7 @@ If you don’t see information that could be helpful on this guide, please let u
 
 ## Technical Transition Guide
 
-Our technical transition guide helps GitHub users prepare for the upgrade, and confirms if users completed linking successfully. [Our IDIR transition guide](https://developer.gov.bc.ca/docs/default/component/bc-developer-guide/use-github-in-bcgov/github-transition-guide/) offers more details about IDIRs. 
+Our technical transition guide helps GitHub users prepare for the upgrade, and confirms if users completed linking successfully. [Our IDIR transition guide](#idir-transition-guide) offers more details about IDIRs. 
 
 After **July 30, 2024**, users cannot access the bcgov GitHub organization if they didn’t link their GitHub ID and IDIR. There are mechanisms in the system that force an IDIR login when you use your GitHub to login. 
 


### PR DESCRIPTION
Updated the following:
* changed link that was pointing to mvp.developer.gov.bc.ca to developer.gov.bc.ca as we are out of mvp stage
* changed link that was point to dev.developer.gov.bc.ca, I changed it to point to an anchor in the page as I think that is where it was supposed to go, would appreciate a second set of eyes on this to make sure it is the correct anchor I chose.
* updated link that was using an anchor that didn't exist, would would appreciate a second set of eyes on this to make sure I chose the correct anchor


