### PR TITLE
Update content-syntax-guide.md

### DIFF
--- a/docs/content-syntax-guide.md
+++ b/docs/content-syntax-guide.md
@@ -296,4 +296,4 @@ The Miro docs have more information on [how to embed Miro boards](https://help.m
 !!! Note
 
 	- Miro boards do not show when the [devhub-techdocs-publish](https://github.com/bcgov/devhub-techdocs-publish/blob/main/docs/index.md#how-to-use-the-docker-image-to-preview-content-locally) tool is used to preview the documentation locally.
-	- DevHub only displays content within an iframe from domains that are explicitly allowed in the DevHub configuration. Currently, this is limited to YouTube and Miro. If you'd like to embed boards and diagrams from sources other than Miro or other content within an `iframe`, please contact the [Developer Experience team](mailto:developer.experience@gov.bc.ca) to discuss needs.
+	- DevHub only displays content within an `iframe` from domains that are explicitly allowed in the DevHub configuration. Currently, this is limited to YouTube and Miro. If you'd like to embed boards and diagrams from sources other than Miro or other content within an `iframe`, please contact the [Developer Experience team](mailto:developer.experience@gov.bc.ca) to discuss needs.

--- a/docs/content-syntax-guide.md
+++ b/docs/content-syntax-guide.md
@@ -296,4 +296,4 @@ The Miro docs have more information on [how to embed Miro boards](https://help.m
 !!! Note
 
 	- Miro boards do not show when the [devhub-techdocs-publish](https://github.com/bcgov/devhub-techdocs-publish/blob/main/docs/index.md#how-to-use-the-docker-image-to-preview-content-locally) tool is used to preview the documentation locally.
-	- DevHub only displays content within an iframe from domains that are explicitly allowed in the DevHub configuration. Currently, this is limited to YouTube and Miro. If you'd like to embed boards and diagrams from sources other than Miro or other content within an iframe, please contact the [Developer Experience team](mailto:developer.experience@gov.bc.ca) to discuss needs.
+	- DevHub only displays content within an iframe from domains that are explicitly allowed in the DevHub configuration. Currently, this is limited to YouTube and Miro. If you'd like to embed boards and diagrams from sources other than Miro or other content within an `iframe`, please contact the [Developer Experience team](mailto:developer.experience@gov.bc.ca) to discuss needs.

--- a/docs/content-syntax-guide.md
+++ b/docs/content-syntax-guide.md
@@ -191,7 +191,7 @@ This text will not be in the admonition block. It will be below it.
 !!! info
 This text will not be in the admonition block. It will be below it.
 
-Here is the [list of supported admonitions](https://squidfunk.github.io/mkdocs-material/reference/admonitions/#supported-types).
+Here's the [list of supported admonitions](https://squidfunk.github.io/mkdocs-material/reference/admonitions/#supported-types).
 
 ### Tabs
 
@@ -296,4 +296,4 @@ The Miro docs have more information on [how to embed Miro boards](https://help.m
 !!! Note
 
 	- Miro boards do not show when the [devhub-techdocs-publish](https://github.com/bcgov/devhub-techdocs-publish/blob/main/docs/index.md#how-to-use-the-docker-image-to-preview-content-locally) tool is used to preview the documentation locally.
-	- DevHub will only display content within an `iframe` from domains that are explicitly allowed in the DevHub configuration. Currently, this is limited to YouTube and Miro. If you would like to embed boards and diagrams from sources other than Miro or other content within an `iframe`, please contact the [Developer Experience team](mailto:developer.experience@gov.bc.ca) to discuss your needs.
+	- DevHub only displays content within an iframe from domains that are explicitly allowed in the DevHub configuration. Currently, this is limited to YouTube and Miro. If you'd like to embed boards and diagrams from sources other than Miro or other content within an iframe, please contact the [Developer Experience team](mailto:developer.experience@gov.bc.ca) to discuss needs.

--- a/docs/content-syntax-guide.md
+++ b/docs/content-syntax-guide.md
@@ -191,6 +191,8 @@ This text will not be in the admonition block. It will be below it.
 !!! info
 This text will not be in the admonition block. It will be below it.
 
+Here is the [list of supported admonitions](https://squidfunk.github.io/mkdocs-material/reference/admonitions/#supported-types).
+
 ### Tabs
 
 ```markdown


### PR DESCRIPTION
Provided a link to the list of supported admonitions.

The documentation only provided examples for 2 types of admonitions. But there are many types that are supported. A natural question is, "what admonitions are available?" The documentation should provide those details.

Techdocs uses the [Admonitions extension](https://squidfunk.github.io/mkdocs-material/reference/admonitions/#admonitions) so I linked to it, rather than recreating the list in the docs. 