### PR TITLE
Fix mermaid diagram not showing in techdocs

### DIFF
--- a/docs/accessibility-resources.md
+++ b/docs/accessibility-resources.md
@@ -4,19 +4,42 @@ The BC Government strives to reach [Web Content Accessibility Guidelines 2.2 AA]
 
 Let’s consider multi-lingual website accessibility and screen readers. The mind map shows a user’s Work in Progress (WIP) as they design a website. They want it compatible with screen readers:
 
-
 ```mermaid
+
+%%{
+  init: {
+    'theme': 'base',
+    'themeVariables': {
+      'primaryColor': '#3333ff',
+      'primaryTextColor': '#fff',
+      'primaryBorderColor': '#7C0000',
+      'lineColor': '#F8B229',
+      'secondaryColor': '#3399ff',
+      'tertiaryColor': '#6699ff'
+    }
+  }
+}%%
+
 mindmap
-  root((mindmap))
-    Tools
-```
+  root((Multi-lingual Accessiblity: <br> Screen readers))
+    Indigenous Languages
+            Unsupported by<br> screen readers
+            BC Sans Typeface
+            Techdocs: Indigenous<br> Languages in Systems
+              
+    Plain language
+        Formatting
+            Headings
+            Descriptive Links
+        Grade 8 <br> readability
+        Translation<br> Services
 
-```mermaid
-graph TD;
-  A-->B;
-  A-->C;
-  B-->D;
-  C-->D;
+    Development
+        Primary<br> language
+            Language<br> codes
+            Language<br> direction
+        Character<br> encoding
+              
 ```
 
 BC Sans Typeface supports special characters and syllabics of Indigenous languages. The technical document [Indigenous Languages in Systems](https://developer.gov.bc.ca/docs/default/component/indigenous-languages-in-systems) shows how to support graphemes. They change written content, but screen readers don’t support Indigenous languages. Software bias creates a culture bias for marginalized communities. Now, Indigenous language only speakers who use screen readers can't access the website.

--- a/docs/accessibility-resources.md
+++ b/docs/accessibility-resources.md
@@ -6,9 +6,17 @@ Let’s consider multi-lingual website accessibility and screen readers. The min
 
 
 ```mermaid
-  mindmap;
-    root((mindmap));
-      Tools;
+mindmap
+  root((mindmap))
+    Tools
+```
+
+```mermaid
+graph TD;
+  A-->B;
+  A-->C;
+  B-->D;
+  C-->D;
 ```
 
 BC Sans Typeface supports special characters and syllabics of Indigenous languages. The technical document [Indigenous Languages in Systems](https://developer.gov.bc.ca/docs/default/component/indigenous-languages-in-systems) shows how to support graphemes. They change written content, but screen readers don’t support Indigenous languages. Software bias creates a culture bias for marginalized communities. Now, Indigenous language only speakers who use screen readers can't access the website.

--- a/docs/accessibility-resources.md
+++ b/docs/accessibility-resources.md
@@ -6,19 +6,6 @@ Let’s consider multi-lingual website accessibility and screen readers. The min
 
 
 ```mermaid
-  %%{
-    init: {
-      'theme': 'base',
-      'themeVariables': {
-        'primaryColor': '#3333ff',
-        'primaryTextColor': '#fff',
-        'primaryBorderColor': '#7C0000',
-        'lineColor': '#F8B229',
-        'secondaryColor': '#3399ff',
-        'tertiaryColor': '#6699ff'
-      }
-    }
-  }%%
   mindmap
     root((Multi-lingual Accessiblity: <br> Screen readers))
       Indigenous Languages

--- a/docs/accessibility-resources.md
+++ b/docs/accessibility-resources.md
@@ -6,38 +6,38 @@ Let’s consider multi-lingual website accessibility and screen readers. The min
 
 
 ```mermaid
-%%{
-  init: {
-    'theme': 'base',
-    'themeVariables': {
-      'primaryColor': '#3333ff',
-      'primaryTextColor': '#fff',
-      'primaryBorderColor': '#7C0000',
-      'lineColor': '#F8B229',
-      'secondaryColor': '#3399ff',
-      'tertiaryColor': '#6699ff'
+  %%{
+    init: {
+      'theme': 'base',
+      'themeVariables': {
+        'primaryColor': '#3333ff',
+        'primaryTextColor': '#fff',
+        'primaryBorderColor': '#7C0000',
+        'lineColor': '#F8B229',
+        'secondaryColor': '#3399ff',
+        'tertiaryColor': '#6699ff'
+      }
     }
-  }
-}%%
-mindmap
-  root((Multi-lingual Accessiblity: <br> Screen readers))
-    Indigenous Languages
-            Unsupported by<br> screen readers
-            BC Sans Typeface
-            Techdocs: Indigenous<br> Languages in Systems
-              
-    Plain language
-        Formatting
-            Headings
-            Descriptive Links
-        Grade 8 <br> readability
-        Translation<br> Services
+  }%%
+  mindmap
+    root((Multi-lingual Accessiblity: <br> Screen readers))
+      Indigenous Languages
+              Unsupported by<br> screen readers
+              BC Sans Typeface
+              Techdocs: Indigenous<br> Languages in Systems
+                
+      Plain language
+          Formatting
+              Headings
+              Descriptive Links
+          Grade 8 <br> readability
+          Translation<br> Services
 
-    Development
-        Primary<br> language
-            Language<br> codes
-            Language<br> direction
-        Character<br> encoding
+      Development
+          Primary<br> language
+              Language<br> codes
+              Language<br> direction
+          Character<br> encoding
 ```
 
 BC Sans Typeface supports special characters and syllabics of Indigenous languages. The technical document [Indigenous Languages in Systems](https://developer.gov.bc.ca/docs/default/component/indigenous-languages-in-systems) shows how to support graphemes. They change written content, but screen readers don’t support Indigenous languages. Software bias creates a culture bias for marginalized communities. Now, Indigenous language only speakers who use screen readers can't access the website.

--- a/docs/accessibility-resources.md
+++ b/docs/accessibility-resources.md
@@ -6,7 +6,6 @@ Let’s consider multi-lingual website accessibility and screen readers. The min
 
 
 ```mermaid
-
 %%{
   init: {
     'theme': 'base',
@@ -20,7 +19,6 @@ Let’s consider multi-lingual website accessibility and screen readers. The min
     }
   }
 }%%
-
 mindmap
   root((Multi-lingual Accessiblity: <br> Screen readers))
     Indigenous Languages
@@ -40,7 +38,6 @@ mindmap
             Language<br> codes
             Language<br> direction
         Character<br> encoding
-              
 ```
 
 BC Sans Typeface supports special characters and syllabics of Indigenous languages. The technical document [Indigenous Languages in Systems](https://developer.gov.bc.ca/docs/default/component/indigenous-languages-in-systems) shows how to support graphemes. They change written content, but screen readers don’t support Indigenous languages. Software bias creates a culture bias for marginalized communities. Now, Indigenous language only speakers who use screen readers can't access the website.

--- a/docs/accessibility-resources.md
+++ b/docs/accessibility-resources.md
@@ -7,24 +7,24 @@ Let’s consider multi-lingual website accessibility and screen readers. The min
 
 ```mermaid
   mindmap
-    root((Multi-lingual Accessiblity: <br> Screen readers))
+    root((Multi-lingual Accessiblity: <br/> Screen readers))
       Indigenous Languages
-              Unsupported by<br> screen readers
+              Unsupported by<br/> screen readers
               BC Sans Typeface
-              Techdocs: Indigenous<br> Languages in Systems
+              Techdocs: Indigenous<br/> Languages in Systems
                 
       Plain language
           Formatting
               Headings
               Descriptive Links
-          Grade 8 <br> readability
-          Translation<br> Services
+          Grade 8 <br/> readability
+          Translation<br/> Services
 
       Development
-          Primary<br> language
-              Language<br> codes
-              Language<br> direction
-          Character<br> encoding
+          Primary<br/> language
+              Language<br/> codes
+              Language<br/> direction
+          Character<br/> encoding
 ```
 
 BC Sans Typeface supports special characters and syllabics of Indigenous languages. The technical document [Indigenous Languages in Systems](https://developer.gov.bc.ca/docs/default/component/indigenous-languages-in-systems) shows how to support graphemes. They change written content, but screen readers don’t support Indigenous languages. Software bias creates a culture bias for marginalized communities. Now, Indigenous language only speakers who use screen readers can't access the website.

--- a/docs/accessibility-resources.md
+++ b/docs/accessibility-resources.md
@@ -8,16 +8,7 @@ Let’s consider multi-lingual website accessibility and screen readers. The min
 ```mermaid
   mindmap
     root((mindmap))
-      Indigenous Languages
-        BC Sans Typeface
-                
-      Plain language
-        Formatting
-          Headings
-          Descriptive Links
-
-      Development
-        Primary
+      Tools
 ```
 
 BC Sans Typeface supports special characters and syllabics of Indigenous languages. The technical document [Indigenous Languages in Systems](https://developer.gov.bc.ca/docs/default/component/indigenous-languages-in-systems) shows how to support graphemes. They change written content, but screen readers don’t support Indigenous languages. Software bias creates a culture bias for marginalized communities. Now, Indigenous language only speakers who use screen readers can't access the website.

--- a/docs/accessibility-resources.md
+++ b/docs/accessibility-resources.md
@@ -7,24 +7,17 @@ Let’s consider multi-lingual website accessibility and screen readers. The min
 
 ```mermaid
   mindmap
-    root((Multi-lingual Accessiblity: <br/> Screen readers))
+    root((mindmap))
       Indigenous Languages
-              Unsupported by<br/> screen readers
-              BC Sans Typeface
-              Techdocs: Indigenous<br/> Languages in Systems
+        BC Sans Typeface
                 
       Plain language
-          Formatting
-              Headings
-              Descriptive Links
-          Grade 8 <br/> readability
-          Translation<br/> Services
+        Formatting
+          Headings
+          Descriptive Links
 
       Development
-          Primary<br/> language
-              Language<br/> codes
-              Language<br/> direction
-          Character<br/> encoding
+        Primary
 ```
 
 BC Sans Typeface supports special characters and syllabics of Indigenous languages. The technical document [Indigenous Languages in Systems](https://developer.gov.bc.ca/docs/default/component/indigenous-languages-in-systems) shows how to support graphemes. They change written content, but screen readers don’t support Indigenous languages. Software bias creates a culture bias for marginalized communities. Now, Indigenous language only speakers who use screen readers can't access the website.

--- a/docs/accessibility-resources.md
+++ b/docs/accessibility-resources.md
@@ -3,7 +3,8 @@
 The BC Government strives to reach [Web Content Accessibility Guidelines 2.2 AA](https://www.w3.org/TR/WCAG22/) (WCAG) for all digital products and services. WCAG sets the basis for web content. The Developer Exchange team designs for Accessibility using an ecosystem approach.
 
 Let’s consider multi-lingual website accessibility and screen readers. The mind map shows a user’s Work in Progress (WIP) as they design a website. They want it compatible with screen readers:
-<br>
+
+
 ```mermaid
 
 %%{

--- a/docs/accessibility-resources.md
+++ b/docs/accessibility-resources.md
@@ -6,9 +6,9 @@ Let’s consider multi-lingual website accessibility and screen readers. The min
 
 
 ```mermaid
-  mindmap
-    root((mindmap))
-      Tools
+  mindmap;
+    root((mindmap));
+      Tools;
 ```
 
 BC Sans Typeface supports special characters and syllabics of Indigenous languages. The technical document [Indigenous Languages in Systems](https://developer.gov.bc.ca/docs/default/component/indigenous-languages-in-systems) shows how to support graphemes. They change written content, but screen readers don’t support Indigenous languages. Software bias creates a culture bias for marginalized communities. Now, Indigenous language only speakers who use screen readers can't access the website.


### PR DESCRIPTION
The mermaid diagram shows in the raw markdown file, but not in techdocs.