### PR TITLE
Update syntax guide mermaid example

### DIFF
--- a/docs/content-syntax-guide.md
+++ b/docs/content-syntax-guide.md
@@ -254,20 +254,23 @@ edited in the VSCode editor while displayed as an svg on the documentation page.
 !!! Note
 	Mermaid diagrams won't show when the [devhub-techdocs-publish](https://github.com/bcgov/devhub-techdocs-publish/blob/main/docs/index.md#how-to-use-the-docker-image-to-preview-content-locally) tool is used to preview the documentation locally. They will show up when published to DevHub's preview or production sites.
 
-````
-```mermaid
-sequenceDiagram
-    A->>B: Request
-    B-->>A: Response
-    A-)B: Acknowledge
+
+```markdown
+mermaid
+  graph TD;
+      A-->B;
+      A-->C;
+      B-->D;
+      C-->D;
+
 ```
-````
 
 ```mermaid
-sequenceDiagram
-    A->>B: Request
-    B-->>A: Response
-    A-)B: Acknowledge
+  graph TD;
+      A-->B;
+      A-->C;
+      B-->D;
+      C-->D;
 ```
 
 ### Videos

--- a/docs/content-syntax-guide.md
+++ b/docs/content-syntax-guide.md
@@ -264,7 +264,6 @@ edited in the VSCode editor while displayed as an svg on the documentation page.
       C-->D;
 ```
 ````
->Note: The backticks (`) were removed from the above code block to prevent the diagram from rendering on this page. Add 3 backticks before "mermaid" and 3 backticks at the end of the code block in your diagram.
 
 ```mermaid
   graph TD;

--- a/docs/content-syntax-guide.md
+++ b/docs/content-syntax-guide.md
@@ -255,14 +255,15 @@ edited in the VSCode editor while displayed as an svg on the documentation page.
 	Mermaid diagrams won't show when the [devhub-techdocs-publish](https://github.com/bcgov/devhub-techdocs-publish/blob/main/docs/index.md#how-to-use-the-docker-image-to-preview-content-locally) tool is used to preview the documentation locally. They will show up when published to DevHub's preview or production sites.
 
 
-```markdown
-mermaid
+````markdown
+```mermaid
   graph TD;
       A-->B;
       A-->C;
       B-->D;
       C-->D;
 ```
+````
 >Note: The backticks (`) were removed from the above code block to prevent the diagram from rendering on this page. Add 3 backticks before "mermaid" and 3 backticks at the end of the code block in your diagram.
 
 ```mermaid

--- a/docs/content-syntax-guide.md
+++ b/docs/content-syntax-guide.md
@@ -256,20 +256,18 @@ edited in the VSCode editor while displayed as an svg on the documentation page.
 
 ````
 ```mermaid
-  stateDiagram-v2
-      A-->B
-      A-->C
-      B-->D
-      C-->D
+sequenceDiagram
+    A->>B: Request
+    B-->>A: Response
+    A-)B: Acknowledge
 ```
 ````
 
 ```mermaid
-  stateDiagram-v2
-      A-->B
-      A-->C
-      B-->D
-      C-->D
+sequenceDiagram
+    A->>B: Request
+    B-->>A: Response
+    A-)B: Acknowledge
 ```
 
 ### Videos

--- a/docs/content-syntax-guide.md
+++ b/docs/content-syntax-guide.md
@@ -256,14 +256,14 @@ edited in the VSCode editor while displayed as an svg on the documentation page.
 
 
 ```markdown
-\`\`\`mermaid
+mermaid
   graph TD;
       A-->B;
       A-->C;
       B-->D;
       C-->D;
-\'\'\'
 ```
+>Note: The backticks (`) were removed from the above code block to prevent the diagram from rendering on this page. Add 3 backticks before "mermaid" and 3 backticks at the end of the code block in your diagram.
 
 ```mermaid
   graph TD;

--- a/docs/content-syntax-guide.md
+++ b/docs/content-syntax-guide.md
@@ -256,20 +256,20 @@ edited in the VSCode editor while displayed as an svg on the documentation page.
 
 ````
 ```mermaid
-  graph TD;
-      A-->B;
-      A-->C;
-      B-->D;
-      C-->D;
+  stateDiagram-v2
+      A-->B
+      A-->C
+      B-->D
+      C-->D
 ```
 ````
 
 ```mermaid
-  graph TD;
-      A-->B;
-      A-->C;
-      B-->D;
-      C-->D;
+  stateDiagram-v2
+      A-->B
+      A-->C
+      B-->D
+      C-->D
 ```
 
 ### Videos

--- a/docs/content-syntax-guide.md
+++ b/docs/content-syntax-guide.md
@@ -256,13 +256,13 @@ edited in the VSCode editor while displayed as an svg on the documentation page.
 
 
 ```markdown
-mermaid
+\`\`\`mermaid
   graph TD;
       A-->B;
       A-->C;
       B-->D;
       C-->D;
-
+\'\'\'
 ```
 
 ```mermaid


### PR DESCRIPTION
Fix syntax on mermaid diagram code block so it renders correctly. `markdown` needs to be added to the 4 backticks so the mermaid diagram code block is properly escaped.
