### PR TITLE
Update bcgov-c private repository request

### DIFF
--- a/docs/use-github-in-bcgov/bc-government-organizations-in-github.md
+++ b/docs/use-github-in-bcgov/bc-government-organizations-in-github.md
@@ -44,7 +44,7 @@ The `bcgov-c` organization stores private repositories with confidential source 
 
 * Use this repository if you need a location for private code, or if you're working towards making the code public.
 * Only the Developer Experience team can create repositories in this organization.
-    * Request a repository by [submitting a request](https://github.com/BCDevOps/devops-requests/issues/new?assignees=MonicaG%2C+oomIRL&labels=github-repo%2C+pending&projects=&template=github_repo_request.md&title=).
+    * Request a repository by [submitting a request](https://citz-do.atlassian.net/servicedesk/customer/portal/2/group/9/create/60).
 * To join this organization, follow [these instructions](#directions-to-sign-up-and-link-your-account-for-bcgov-c).
 
 


### PR DESCRIPTION
It appears that private repository requests are no longer taken via the GitHub [devops-requests](https://github.com/bcgov/devops-requests) repository. See [commit b4fb8ba](https://github.com/bcgov/devops-requests/commit/b4fb8ba8290f8d97f17320bc76c6c0599920a91f) where the linked issue template was deleted.

Going to the new issues list, the provided link is https://citz-do.atlassian.net/servicedesk/customer/portal/2/group/9/create/60. So this should probably be updated in the documentation so users don't get sent to an issue template which no longer exists.