### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -1,5 +1,8 @@
 name: Build TechDocs with DevHub TechDocs Publish Action
 
+permissions:
+    contents: read
+
 on:
     workflow_dispatch:
     push:


### PR DESCRIPTION
Potential fix for [https://github.com/bcgov/bcdg/security/code-scanning/1](https://github.com/bcgov/bcdg/security/code-scanning/1)

To fix the issue, we will add a `permissions` block to the workflow. Since the workflow primarily involves checking out the repository and publishing TechDocs content, it likely only requires `contents: read` permissions. If additional permissions are required for specific actions, they can be added explicitly. The `permissions` block will be added at the workflow level to apply to all jobs.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
