### PR TITLE
Add page describing security features documentation for BC government GitHub users

### DIFF
--- a/docs/use-github-in-bcgov/github-security.md
+++ b/docs/use-github-in-bcgov/github-security.md
@@ -1,0 +1,33 @@
+# Security Features for BC Government GitHub users
+
+The BC government GitHub organizations (`bcgov` and `bcgov-c`) have various security features available to help protect the code and repositories within them. This page will highlight some of these features and provide recommendations on using them for BC government development teams.
+
+## Availability
+
+The features described here are available and enabled in both `bcgov` and `bcgov-c` organizations.
+
+## Cost
+
+In `bcgov` there is no cost to the organization for these security features as all repositories are public, and GitHub makes them available for free for public repositories. In `bcgov-c` there is a cost associated with the use of the features since the repositories are private, for which GitHub charges a fee; however the cost in `bcgov-c` is currently covered by the Developer Experience Team, so there is no cost to individual teams or ministries.
+
+## Features
+
+The following features are some of the major security features available in the BC government GitHub organizations:
+ 
+- [Code scanning](https://docs.github.com/en/code-security/code-scanning/introduction-to-code-scanning/about-code-scanning: This feature scans code for security vulnerabilities and coding errors.
+- [Secret scanning](https://docs.github.com/en/code-security/secret-scanning/introduction/about-secret-scanning): This feature scans repositories and commits for sensitive information such as API keys, passwords, and other secrets. 
+- [DependaBot](https://docs.github.com/en/code-security/dependabot): This feature scans repositories for outdated or vulnerable dependencies and provides recommendations for fixing problems, including via automated pull requests.
+
+## Recommendations
+
+Application and code security are a complex topics, and the features described above are just a few of the many tools available to help teams secure their code. The Developer Experience Team has the following recommendations specifig to these features provided within GitHub:
+
+- Keep the features enabled in your repositories. Even is some features can be reconfigured at the repository level, they are there to help you and your team secure your code.
+- Use the Security Overview page for your repositories to see any issues detected by GitHub's security features. The Security Overview page is available in the repository under the "Security" tab.
+- If you work on multiple repositories within `bcgov` or `bcgov-c`, you can use the [Security Overview for the organization](https://github.com/orgs/bcgov/security/overview) to see a summary of all security issues across multiple repositories in the organization.
+- Take action on any issue surfaced by GitHub security features as soon as possible. The sooner you address issues - even they are false positives that you dismiss without changes - the less likely they are to become a problem or become "noise" that you ignore.
+
+
+
+
+

--- a/docs/use-github-in-bcgov/github-security.md
+++ b/docs/use-github-in-bcgov/github-security.md
@@ -14,7 +14,7 @@ In `bcgov` there is no cost to the organization for these security features as a
 
 The following features are some of the major security features available in the BC government GitHub organizations:
  
-- [Code scanning](https://docs.github.com/en/code-security/code-scanning/introduction-to-code-scanning/about-code-scanning: This feature scans code for security vulnerabilities and coding errors.
+- [Code scanning](https://docs.github.com/en/code-security/code-scanning/introduction-to-code-scanning/about-code-scanning): This feature scans code for security vulnerabilities and coding errors.
 - [Secret scanning](https://docs.github.com/en/code-security/secret-scanning/introduction/about-secret-scanning): This feature scans repositories and commits for sensitive information such as API keys, passwords, and other secrets. 
 - [DependaBot](https://docs.github.com/en/code-security/dependabot): This feature scans repositories for outdated or vulnerable dependencies and provides recommendations for fixing problems, including via automated pull requests.
 

--- a/docs/use-github-in-bcgov/github-security.md
+++ b/docs/use-github-in-bcgov/github-security.md
@@ -25,7 +25,7 @@ Application and code security are a complex topics, and the features described a
 - Keep the features enabled in your repositories. Even if some features can be reconfigured at the repository level, they are there to help you and your team secure your code.
 - Use the Security Overview page for your repositories to see any issues detected by GitHub's security features. The Security Overview page is available in the repository under the "Security" tab.
 - If you work on multiple repositories within `bcgov` or `bcgov-c`, you can use the [Security Overview for the organization](https://github.com/orgs/bcgov/security/overview) to see a summary of all security issues across multiple repositories in the organization.
-- Take action on any issue surfaced by GitHub security features as soon as possible. The sooner you address issues - even they are false positives that you dismiss without changes - the less likely they are to become a problem or become "noise" that you ignore.
+- Take action on any issue surfaced by GitHub security features as soon as possible. The sooner you address issues - even if they are false positives that you dismiss without changes - the less likely they are to become a problem or become "noise" that you ignore.
 
 
 

--- a/docs/use-github-in-bcgov/github-security.md
+++ b/docs/use-github-in-bcgov/github-security.md
@@ -22,7 +22,7 @@ The following features are some of the major security features available in the 
 
 Application and code security are a complex topics, and the features described above are just a few of the many tools available to help teams secure their code. The Developer Experience Team has the following recommendations specific to these features provided within GitHub:
 
-- Keep the features enabled in your repositories. Even is some features can be reconfigured at the repository level, they are there to help you and your team secure your code.
+- Keep the features enabled in your repositories. Even if some features can be reconfigured at the repository level, they are there to help you and your team secure your code.
 - Use the Security Overview page for your repositories to see any issues detected by GitHub's security features. The Security Overview page is available in the repository under the "Security" tab.
 - If you work on multiple repositories within `bcgov` or `bcgov-c`, you can use the [Security Overview for the organization](https://github.com/orgs/bcgov/security/overview) to see a summary of all security issues across multiple repositories in the organization.
 - Take action on any issue surfaced by GitHub security features as soon as possible. The sooner you address issues - even they are false positives that you dismiss without changes - the less likely they are to become a problem or become "noise" that you ignore.

--- a/docs/use-github-in-bcgov/github-security.md
+++ b/docs/use-github-in-bcgov/github-security.md
@@ -8,7 +8,9 @@ The features described here are available and enabled in both `bcgov` and `bcgov
 
 ## Cost
 
-In `bcgov` there is no cost to the organization for these security features as all repositories are public, and GitHub makes them available for free for public repositories. In `bcgov-c` there is a cost associated with the use of the features since the repositories are private, for which GitHub charges a fee; however the cost in `bcgov-c` is currently covered by the Developer Experience Team, so there is no cost to individual teams or ministries.
+In the `bcgov` organization, there is no cost for these security features because all repositories are public, and GitHub provides them for free for public repositories. 
+
+In the `bcgov-c` organization, there is a cost for these features since the repositories are private, and GitHub charges a fee for private repositories. However, this cost is currently covered by the Developer Experience Team, so individual teams or ministries do not need to pay.
 
 ## Features
 

--- a/docs/use-github-in-bcgov/github-security.md
+++ b/docs/use-github-in-bcgov/github-security.md
@@ -20,7 +20,7 @@ The following features are some of the major security features available in the 
 
 ## Recommendations
 
-Application and code security are a complex topics, and the features described above are just a few of the many tools available to help teams secure their code. The Developer Experience Team has the following recommendations specifig to these features provided within GitHub:
+Application and code security are a complex topics, and the features described above are just a few of the many tools available to help teams secure their code. The Developer Experience Team has the following recommendations specific to these features provided within GitHub:
 
 - Keep the features enabled in your repositories. Even is some features can be reconfigured at the repository level, they are there to help you and your team secure your code.
 - Use the Security Overview page for your repositories to see any issues detected by GitHub's security features. The Security Overview page is available in the repository under the "Security" tab.

--- a/docs/use-github-in-bcgov/github-security.md
+++ b/docs/use-github-in-bcgov/github-security.md
@@ -16,7 +16,7 @@ The following features are some of the major security features available in the 
  
 - [Code scanning](https://docs.github.com/en/code-security/code-scanning/introduction-to-code-scanning/about-code-scanning): This feature scans code for security vulnerabilities and coding errors.
 - [Secret scanning](https://docs.github.com/en/code-security/secret-scanning/introduction/about-secret-scanning): This feature scans repositories and commits for sensitive information such as API keys, passwords, and other secrets. 
-- [DependaBot](https://docs.github.com/en/code-security/dependabot): This feature scans repositories for outdated or vulnerable dependencies and provides recommendations for fixing problems, including via automated pull requests.
+- [Dependabot](https://docs.github.com/en/code-security/dependabot): This feature scans repositories for outdated or vulnerable dependencies and provides recommendations for fixing problems, including via automated pull requests.
 
 ## Recommendations
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -29,6 +29,7 @@ nav:
   - GitHub in the B.C. government:
       - BC Government organizations in GitHub: use-github-in-bcgov/bc-government-organizations-in-github.md
       - B.C. Government GitHub Quick Reference: use-github-in-bcgov/quick-reference.md
+      - Security Features for BC Government GitHub Users: use-github-in-bcgov/github-security.md
       - Remove a user's BCGov GitHub access: use-github-in-bcgov/remove-user-bcgov-github-access.md
       - GitHub SSO transition guide: use-github-in-bcgov/github-transition-guide.md
       - Evaluate open-source content: use-github-in-bcgov/evaluate-open-source-content.md


### PR DESCRIPTION
This pull request adds documentation on security features available to BC Government GitHub users and updates the navigation menu to include the new documentation. Below are the most important changes:

### Documentation Updates:
* Added a new file, `use-github-in-bcgov/github-security.md`, which outlines security features available in the `bcgov` and `bcgov-c` GitHub organizations. The document includes details on feature availability, cost, descriptions of features (e.g., code scanning, secret scanning, Dependabot), and recommendations for using these features.

### Navigation Updates:
* Updated the `mkdocs.yml` file to include the new "Security Features for BC Government GitHub Users" page in the navigation menu under "GitHub in the B.C. government."