### PR TITLE
Fix Markdown formatting for devhub_appearance.png image tag

### DIFF
--- a/docs/content-partner-guide.md
+++ b/docs/content-partner-guide.md
@@ -63,7 +63,7 @@ The images below provide an example of how a Markdown snippet in GitHub (first i
 
 ![A screenshot of the Mardown source ](images/markdown_source.png)
 
-!A screenshot of TechDocs-generated documentation displayed within DevHub.](images/devhub_appearance.png)
+![A screenshot of TechDocs-generated documentation displayed within DevHub.](images/devhub_appearance.png)
 
 ## How do we get set up to have our documentation published in DevHub?
 


### PR DESCRIPTION
This fixes the image not loading here:

<img width="3312" height="1882" alt="Screenshot of Content Partner Guide page with DevHub Appearance broken tag" src="https://github.com/user-attachments/assets/e917aa8e-7844-48a8-be8e-6f52a3c36681" />
