### PR TITLE
Clarify sysdig example

### DIFF
--- a/docs/webhooks/create-workflow.md
+++ b/docs/webhooks/create-workflow.md
@@ -130,7 +130,7 @@ Your MS Teams channel should now have a message like the following:
 
 Test and Production URLs should not be used to separate production and non-production environments. 
 
-Recommended approach:
+#### Recommended approach for production and non-production notifications
 
 * Create separate Teams channels for production and non-production notifications
 * Use the webhook Production URL for both the production and non-production environments of your system.

--- a/docs/webhooks/troubleshooting.md
+++ b/docs/webhooks/troubleshooting.md
@@ -80,6 +80,8 @@ return { json: { isProd, body } };
 ```
 Then the payload becomes `{{ $json.body }}` in the connector node.
 
+Note: This code sample uses the `isProd` const to indicate whether the alert is from a production environment or not. The output is used by an `if` node to [direct the message to the appropriate channel](create-workflow.md#recommended-approach-for-production-and-non-production-notifications).
+
 ### Preview shows success but no Teams message
 Preview mode does not send messages. It only displays formatted output and is intended for testing. 
 


### PR DESCRIPTION
Added clarification to the sysdig code example:

* Explain what the isProd const is
* Add link to section with example using isProd const
* Switched from bold to header format so example could be directly linked to



